### PR TITLE
Swap start_time and end_time from last_minutes

### DIFF
--- a/lib/spotdog/cli.rb
+++ b/lib/spotdog/cli.rb
@@ -31,7 +31,7 @@ module Spotdog
 
     def parse_start_time(options)
       if options[:last_minutes]
-        current_time
+        current_time - options[:last_minutes] * 60
       else
         options[:start_time] ? Time.parse(options[:start_time]) : nil
       end
@@ -39,7 +39,7 @@ module Spotdog
 
     def parse_end_time(options)
       if options[:last_minutes]
-        current_time - options[:last_minutes] * 60
+        current_time
       else
         options[:end_time] ? Time.parse(options[:end_time]) : nil
       end

--- a/spec/lib/spotdog/cli_spec.rb
+++ b/spec/lib/spotdog/cli_spec.rb
@@ -85,8 +85,8 @@ module Spotdog
               instance_types: ["c4.large", "c4.xlarge"],
               max_results: max_results,
               product_descriptions: ["Linux/UNIX (Amazon VPC)", "SUSE Linux"],
-              start_time: current_time,
-              end_time: current_time - last_minutes * 60,
+              start_time: current_time - last_minutes * 60,
+              end_time: current_time,
             )
             expect(Spotdog::Datadog).to receive(:send_price_history).with(api_key, spot_price_history)
 


### PR DESCRIPTION
Currently `--last-minutes` options causes error the below:

```
/Users/dtan4/.anyenv/envs/rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/aws-sdk-core-2.1.26/lib/seahorse/client/plugins/raise_response_errors.rb:15:in `call': Start time cannot be later than the end time. (Aws::EC2::Errors::InvalidInput)
```
